### PR TITLE
curl_multi optimizations in waitForData

### DIFF
--- a/src/AsyncRequest/AsyncRequest.php
+++ b/src/AsyncRequest/AsyncRequest.php
@@ -87,7 +87,13 @@ class AsyncRequest
 		}
 
 		while (curl_multi_exec($this->handle, $runningCount) === CURLM_CALL_MULTI_PERFORM);
-		curl_multi_select($this->handle, $timeout);
+		if($runningCount > 0){
+			// still unfinished handles
+			if(curl_multi_select($this->handle, $timeout) > 0) {
+				// new data available on handles before $timeout, lets fetch it
+				while (curl_multi_exec($this->handle, $runningCount) === CURLM_CALL_MULTI_PERFORM);
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
the old code would run the multi_handles, then wait until there was new data available on any of the sockets -or- until $timeout, and then return (and not fetch the new data),

the new code will run the multi handles, then wait until there is new data available on any of the sockets -or- until $timeout, and if there is new data available on the sockets before $timeout, it will fetch the new data as well,

this should make the function faster (waiting until there is data, and not fetching it, like the old function did, was kindof dumb)

also the new code only runs select() if there are unfinished handles, the old code would run select() even if all handles had finished (that might save some cpu)